### PR TITLE
Add feedback for "fill in the blanks" left in exercise.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: gradethis
+Package: gradethislee
 Type: Package
 Title: Tools for "grading" student exercises in learnr tutorials
 Version: 0.1.0.9004

--- a/R/grade_code.R
+++ b/R/grade_code.R
@@ -147,6 +147,13 @@ is_code_identical <- function(user = NULL, solution = NULL) {
   if (is.null(user)) {
     stop("I didn't receive your code. Did you write any?")
   }
+  
+  # Many tutorial authors use learnr and gradethis for creating "fill in the blanks exercises".
+  # This checks that the students has not left and blanks (3 underscores) in their solution
+  # This is ignored if the solution code contains blanks.
+  if (grepl("___", user) && !grepl("___", solution)) {
+    stop("Your code still contains blanks. Please replace all blanks with valid code.")
+  }
 
   # user and solution are expressions with `srcref`s. Must compare each element. Can not compare as a whole unit
   if (!identical(class(user), class(solution))) {


### PR DESCRIPTION
Many instructors create fill in the blanks exercises in their tutorials, using three underscores to indicate a blank space, for example. The aim of this PR is to add particular feedback if the student leaves any of these blanks when the submit their code.